### PR TITLE
fixed #20

### DIFF
--- a/yiban/Apis/Task.py
+++ b/yiban/Apis/Task.py
@@ -12,8 +12,8 @@ from yiban.Core import SchoolBasedAuth
 from yiban.Core import EpidemicPrevention
 
 class Task:
-    def __init__(self, access_token):
-        req = SchoolBasedAuth(access_token)._auth()
+    def __init__(self, mobile: str, password: str):
+        req = SchoolBasedAuth(mobile=mobile, password=password)._auth()
 
         self.task_feedback = TaskFeedback(req)             # 任务反馈
         self.epidemic_prevention = EpidemicPrevention(req) # 疫情防控

--- a/yiban/Apis/User.py
+++ b/yiban/Apis/User.py
@@ -5,17 +5,17 @@
 
 """ User Class """
 
-from yiban.Core import Login
+from yiban.Core import SchoolBasedAuth
 
 class User:
     def __init__(self, mobile: str, password: str):
         self.__mobile = mobile
         self.__password = password
-        self.__access_token = Login().get_user_access_token(self.__mobile, self.__password)
+        # self.__access_token = Login().get_user_access_token(self.__mobile, self.__password)
 
-    def get_user_access_token(self) -> str:
-        """获取用户登录密钥"""
-        return self.__access_token
+    # def get_user_access_token(self) -> str:
+    #     """获取用户登录密钥"""
+    #     return self.__access_token
 
     # def get_user_name(self) -> str:
     #     """获取用户名"""

--- a/yiban/Apis/Yiban.py
+++ b/yiban/Apis/Yiban.py
@@ -26,6 +26,6 @@ class Yiban(
         super().__init__(mobile=mobile, password=password)  # init User
         
         try:
-            super(User, self).__init__(access_token=self.get_user_access_token())  # init Task
+            super(User, self).__init__(mobile=mobile, password=password)  # init Task
         except:
             pass

--- a/yiban/Core/SchoolBased.py
+++ b/yiban/Core/SchoolBased.py
@@ -21,8 +21,8 @@ class SchoolBased:
         return { "Origin": "https://c.uyiban.com", "User-Agent": "Yiban", "AppVersion": "5.0" }
 
     @staticmethod
-    def cookies(access_token) -> Dict: 
-        return { "yiban_user_token": access_token, "loginToken": access_token, "csrf_token": "00000" }
+    def cookies() -> Dict: 
+        return {  "csrf_token": "00000" }
 
     @staticmethod
     def _log(msg: str = None, level: int = 20) -> None:


### PR DESCRIPTION
先前使用的登录接口 www.yiban.cn 无法正常使用，对改接口测试可知，目前该接口需要post数据为
 - account ： 手机号
 - password ： 经过加密后的密码，易班的login.js并未加密，通过阅读代码可知，密码通过rsa进行加密，rsa加密公钥被直接写在了html中，可以在 https://www.yiban.cn/login?go=https%3A%2F%2Fwww.yiban.cn%2F 的 id 为 "login-pr" 的 <ul> 元素中找到，值得注意的是该密钥每次刷新都会发生变化
 - captcha：为空
 - keysTime 同 password ，其允许值可在html中找到，推测为rsa密钥的时间戳
 - rid：数美验证码id，因易班开启验证码验证（即使之前登陆过），此字段已经不可被跳过，允许值在通过机器人验证后才能获取，正是该字段导致脚本目前无法继续使用该接口

------ 

通过浏览器直接登录 c.uyiban.com  ，发现易班校本化登录并不是通过 www.yiban.cn ，而是 https://oauth.yiban.cn/code/html?client_id=95626fa3080300ea&redirect_uri=https://f.yiban.cn/iapp7463 。
发现通过该接口登录时不需要进行机器人验证，故产生使用该接口进行登录的想法
通过抓包验证可知，通过该接口进行登录，需要post以下数据
 - oauth_uname： 手机号
 - oauth_upwd： 经过加密后的密码，由先前对 www.yiban.cn 登录的分析，怀疑改接口提交的密码依旧是使用rsa加密，直接在html源码中翻看，在一个 id 为 key 的 input 中找到了rsa公钥，编码测试，确为rsa加密，同时该公钥依旧每次刷新时改变
 - client_id：意义不明，直接使用原版代码中的定义
 - redirect_uri： 大概时跳转链接，具体意义不明，同上。
编码测试后，发现该接口可以正常登录，晚点签到正常，但是因为接口的改变，无法再次获取 access_token ，暂时不明有什么影响。

-------

题外话：
在调试的过程中发现，通过对 https://api.uyiban.com/base/c/auth/yiban 接口访问，可以获取到部分个人信息，如：学校名称以及姓名